### PR TITLE
Added metadata.rb to try to fix this error I get when I try to install it via librarian.

### DIFF
--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -36,46 +36,50 @@ if Chef::Config[:solo]
   require_relative 'parser.rb'
   
   class Chef
-    class Recipe
-      
-      # Overwrite the search method of recipes to operate locally by using
-      # data found in data_bags.
-      # Only very basic lucene syntax is supported and also sorting the result
-      # is not implemented, if this search method does not support a given query
-      # an exception is raised.
-      # This search() method returns a block iterator or an Array, depending
-      # on how this method is called.
-      def search(bag_name, query=nil, sort=nil, start=0, rows=1000, &block)
-        if !sort.nil?
-          raise "Sorting search results is not supported"
-        end
-        @_query = Query.parse(query)
-        if @_query.nil?
-          raise "Query #{query} is not supported"
-        end
-        if block_given?
-          pos = 0
-        else
-          result = []
-        end
-        data_bag(bag_name.to_s).each do |bag_item_id|
-          bag_item = data_bag_item(bag_name.to_s, bag_item_id)
-          if @_query.match(bag_item)
-            if block_given?
-              if (pos >= start and pos < (start + rows))
-                yield bag_item
+    module Mixin
+      module Language
+
+        # Overwrite the search method of recipes to operate locally by using
+        # data found in data_bags.
+        # Only very basic lucene syntax is supported and also sorting the result
+        # is not implemented, if this search method does not support a given query
+        # an exception is raised.
+        # This search() method returns a block iterator or an Array, depending
+        # on how this method is called.
+        def search(bag_name, query=nil, sort=nil, start=0, rows=1000, &block)
+          if !sort.nil?
+            raise "Sorting search results is not supported"
+          end
+          @_query = Query.parse(query)
+          if @_query.nil?
+            raise "Query #{query} is not supported"
+          end
+          if block_given?
+            pos = 0
+          else
+            result = []
+          end
+          data_bag(bag_name.to_s).each do |bag_item_id|
+            bag_item = data_bag_item(bag_name.to_s, bag_item_id)
+            if @_query.match(bag_item)
+              if block_given?
+                if (pos >= start and pos < (start + rows))
+                  yield bag_item
+                end
+                pos += 1
+              else
+                result << bag_item
               end
-              pos += 1
-            else
-              result << bag_item
             end
           end
+          if !block_given?
+            return result.slice(start, rows)
+          end
         end
-        if !block_given?
-          return result.slice(start, rows)
-        end
+
       end
     end
   end
 
 end
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,0 +1,10 @@
+maintainer       "edelight GmbH"
+maintainer_email "markus.korn@edelight.de"
+license          "Apache 2.0"
+description      "Data bag search for Chef Solo"
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          "0.4.0"
+
+%w{ ubuntu debian redhat centos fedora freebsd}.each do |os|
+  supports os
+end


### PR DESCRIPTION
To reproduce the problem, install librarian, add this line to your Cheffile:

``` ruby
cookbook 'chef-solo-search', :git => 'git://github.com/edelight/chef-solo-search.git'
```

and run librarian-chef.

The workaround is to use a repository with a metadata.rb file:

``` ruby
cookbook 'chef-solo-search', :git => 'git://github.com/TylerRick/chef-solo-search.git'
```
