### PR TITLE
Simple chef-solo node search

### DIFF
--- a/tests/data/data_bags/node/alpha.json
+++ b/tests/data/data_bags/node/alpha.json
@@ -1,0 +1,10 @@
+{
+  "id":       "alpha",
+  "name":     "alpha.example.com",
+  "json_class": "Chef::Node",
+  "run_list": ["role[test_server]"],
+  "chef_environment": "default",
+  "automatic": {
+    "hostname": "alpha.example.com"
+  }
+}

--- a/tests/data/data_bags/node/beta.json
+++ b/tests/data/data_bags/node/beta.json
@@ -1,0 +1,10 @@
+{
+  "id":       "beta",
+  "name":     "beta.example.com",
+  "json_class": "Chef::Node",
+  "run_list": ["role[test_server]","role[beta_server]"],
+  "chef_environment": "default",
+  "automatic": {
+    "hostname": "beta.example.com"
+  }
+}

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -26,7 +26,7 @@ Chef::Config[:solo] = true
 Chef::Config[:data_bag_path] = "tests/data/data_bags"
 
 # load the extension
-require "search.rb"
+require File.expand_path('../../libraries/search', __FILE__)
 
 def search(*args, &block)
   # wrapper around creating a new Recipe instance and calling search on it

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -152,12 +152,6 @@ class TestSearch < Test::Unit::TestCase
     assert nodes.length == 1
   end
   
-  def test_chef_environment
-    assert_raise(RuntimeError) {
-        search(:users, "username:speedy AND chef_environment:_default")
-    }
-  end
-  
   def test_wildcards
     nodes = search(:users, "gender:f??ale")
     assert nodes.length == 1

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -36,7 +36,7 @@ def search(*args, &block)
   return Chef::Recipe.new("test_cookbook", "test_recipe", run_context).search(*args, &block)
 end
 
-class TestSearch < Test::Unit::TestCase
+class TestSearchDB < Test::Unit::TestCase
   
   def test_search_all
     # try to get data of all users
@@ -183,5 +183,28 @@ class TestSearch < Test::Unit::TestCase
     assert nodes.length == 1
     nodes = search(:users, "address_street_floor:1")
     assert nodes.length == 1
+  end
+end
+
+class TestSearchNode < Test::Unit::TestCase
+  def test_list_nodes
+    nodes = search(:node)
+    assert_equal Chef::Node, nodes.first.class
+    assert_equal 2, nodes.length
+  end
+
+  def test_search_node_with_wide_filter
+    nodes = search(:node, "role:test_server AND chef_environment:default")
+    assert_equal 2, nodes.length
+  end
+
+  def test_search_node_with_narrow_filter
+    nodes = search(:node, "role:beta_server")
+    assert_equal 1, nodes.length
+  end
+
+  def test_search_node_with_attr_filter
+    nodes = search(:node, "hostname:beta.example.com")
+    assert_equal 1, nodes.length
   end
 end


### PR DESCRIPTION
Hi,

This patch corrects an error in the existing tests and adds simple support for keeping a model of your chef nodes in flat files (sort of a special type of data bag).

This has been useful for me when modeling complex environments without chef-server. Comments welcome.

Cheers,
--bpo
