### PR TITLE
Special case for lucene "anything range" [* TO *]

### DIFF
--- a/libraries/parser.rb
+++ b/libraries/parser.rb
@@ -77,7 +77,19 @@ module Lucene
   class FiledRange < Treetop::Runtime::SyntaxNode
   end
   
-  class InclFieldRange < FieldRange
+  # we handle '[* TO *]' as a special case since it is common in
+  # cookbooks for matching the existence of keys
+  class InclFieldRange
+    def match(item)
+      field = self.elements[0].text_value
+      range_start = self.elements[1].transform
+      range_end = self.elements[2].transform
+      if range_start == "*" and range_end == "*"
+        !!item[field]
+      else
+        raise "Ranges not really supported yet"
+      end
+    end
   end
   
   class ExclFieldRange < FieldRange

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -123,6 +123,17 @@ class TestSearchDB < Test::Unit::TestCase
     assert nodes.length == 2
   end
   
+  def test_any_value_lucene_range
+    nodes = search(:users, "address:[* TO *]")
+    assert nodes.length == 2
+  end
+  
+  def test_general_lucene_range_fails
+    assert_raises RuntimeError do
+      nodes = search(:users, "children:[aaa TO zzz]")
+    end
+  end
+  
   def test_block_usage
     # bracket syntax
     result = []


### PR DESCRIPTION
This "anything range" is used in a few popular cookbooks.  I needed it for the opsware munin cookbook.
