### PR TITLE
Add default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,2 @@
+# This file is intentionally blank, which allows this
+# entire repository to be used as a cookbook

--- a/tests/Gemfile
+++ b/tests/Gemfile
@@ -1,0 +1,6 @@
+source :rubygems
+
+gem 'chef'
+gem 'ruby-wmi'
+gem 'test-unit'
+gem 'win32-service'


### PR DESCRIPTION
Hello!

I added a blank default recipe file (recipes/default.rb) so that your repository can be used as a cookbook by Berkshelf. By adding the blank file, Berkshelf "knows" how to download the repo for use in projects like my Linux virtual-machine builder (https://github.com/webcoyote/linux-vm). 

I also added tests/Gemfile so that the dependencies required for testing can be easily downloaded and installed in the event that they're not already on the system.

Finally, I ran your unit tests and nothing broke :)

Incidentally, your project is great! I was able to easily use your project with the Opscode "users" cookbook so that I could utilize their users::sysadmins recipe without requiring the use of Chef Server.

Thanks,

Pat
