### PR TITLE
Use Chef::JSONCompat to parse node json files

### DIFF
--- a/libraries/search/overrides.rb
+++ b/libraries/search/overrides.rb
@@ -65,7 +65,7 @@ module Search
       _result = []
       Dir.glob(File.join(Chef::Config[:data_bag_path], "node", "*.json")).map do |f|
         # parse and hashify the node
-        node = Chef::Node.json_create(JSON.parse(IO.read(f)))
+        node = Chef::JSONCompat.from_json(IO.read(f))
         if _query.match(node.to_hash)
           _result << node
         end
@@ -77,7 +77,7 @@ module Search
       _result = []
       Dir.glob(File.join(Chef::Config[:role_path], "*.json")).map do |f|
         # parse and hashify the role
-        role = Chef::Role.json_create(JSON.parse(IO.read(f)))
+        role = Chef::JSONCompat.from_json(IO.read(f))
         if _query.match(role.to_hash)
           _result << role
         end

--- a/tests/data/data_bags/node/without_json_class.json
+++ b/tests/data/data_bags/node/without_json_class.json
@@ -1,0 +1,7 @@
+{
+  "id": "without_json_class",
+  "name": "wjc.example.com",
+  "chef_environment": "default",
+  "hostname": "alpha.example.com",
+  "run_list": ["role[test_server]"]
+}

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -193,7 +193,7 @@ module SearchNodeTests
   def test_list_nodes
     nodes = search(:node)
     assert_equal Chef::Node, nodes.first.class
-    assert_equal 2, nodes.length
+    assert_equal 3, nodes.length
   end
 
   def test_search_node_with_wide_filter
@@ -209,6 +209,11 @@ module SearchNodeTests
   def test_search_node_with_attr_filter
     nodes = search(:node, "hostname:beta.example.com")
     assert_equal 1, nodes.length
+  end
+
+  def test_search_node_without_json_class
+    nodes = search(:node, "chef_environment:default")
+    assert_equal 3, nodes.length
   end
 end
 


### PR DESCRIPTION
This allows you to search node files that don't a json_class key.
