### PR TITLE
metadata.rb name setting

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "chef-solo-search"
 maintainer       "edelight GmbH"
 maintainer_email "markus.korn@edelight.de"
 license          "Apache 2.0"


### PR DESCRIPTION
Berkshelf 1.2.0 fails on Ridley 0.8.1 due to "name" setting absence in metadata.rb:

Uploading chef-solo-search (0.4.0) to: 'https://chef.example.com'
Ridley::Errors::HTTPBadRequest {"error":["Field 'metadata.name' invalid"]}
