### PR TITLE
Improve searching for nodes by role

### DIFF
--- a/libraries/search/overrides.rb
+++ b/libraries/search/overrides.rb
@@ -64,8 +64,21 @@ module Search
     def search_nodes(_query, start, rows, &block)
       _result = []
       Dir.glob(File.join(Chef::Config[:data_bag_path], "node", "*.json")).map do |f|
-        # parse and hashify the node
-        node = Chef::JSONCompat.from_json(IO.read(f))
+        content = File.read(f)
+        json = Yajl::Parser.parse(content)
+        json["recipes"]    ||= [] # Hacks, because chef assumes that this keys always exists.
+        json["automatic"]  ||= {}
+        json["json_class"] ||= "Chef::Node" # Accept node files without json class declaration
+
+        if json.has_key?("hostname")
+          json["automatic"]["hostname"] = json.delete("hostname")
+        end
+
+        node = Chef::Node.json_create(json) # Create a chef node to ensure expansion of data
+
+        # Forcibly set our custom automatic variables
+        node.instance_variable_set(:@automatic, Chef::Node::VividMash.new(node, json["automatic"]))
+
         if _query.match(node.to_hash)
           _result << node
         end

--- a/tests/data/data_bags/node/alpha.json
+++ b/tests/data/data_bags/node/alpha.json
@@ -3,7 +3,7 @@
   "name":     "alpha.example.com",
   "json_class": "Chef::Node",
   "run_list": ["role[test_server]"],
-  "chef_environment": "default",
+  "chef_environment": "_default",
   "automatic": {
     "hostname": "alpha.example.com"
   }

--- a/tests/data/data_bags/node/beta.json
+++ b/tests/data/data_bags/node/beta.json
@@ -2,8 +2,8 @@
   "id":       "beta",
   "name":     "beta.example.com",
   "json_class": "Chef::Node",
-  "run_list": ["role[test_server]","role[beta_server]"],
-  "chef_environment": "default",
+  "run_list": ["role[test_server]","role[app_server]"],
+  "chef_environment": "_default",
   "automatic": {
     "hostname": "beta.example.com"
   }

--- a/tests/data/data_bags/node/without_json_class.json
+++ b/tests/data/data_bags/node/without_json_class.json
@@ -1,7 +1,7 @@
 {
   "id": "without_json_class",
   "name": "wjc.example.com",
-  "chef_environment": "default",
+  "chef_environment": "_default",
   "hostname": "wjc.example.com",
   "run_list": ["role[test_server]"]
 }

--- a/tests/data/data_bags/node/without_role.json
+++ b/tests/data/data_bags/node/without_role.json
@@ -1,0 +1,10 @@
+{
+  "id":       "without_role",
+  "name":     "without_role.example.com",
+  "json_class": "Chef::Node",
+  "run_list": [],
+  "chef_environment": "_default",
+  "automatic": {
+    "hostname": "withoutrole.example.com"
+  }
+

--- a/tests/data/roles/app-server.rb
+++ b/tests/data/roles/app-server.rb
@@ -1,0 +1,3 @@
+description "App server"
+name "app-server"
+run_list(["recipe[apache]"])

--- a/tests/data/roles/app_server.rb
+++ b/tests/data/roles/app_server.rb
@@ -1,3 +1,3 @@
 description "App server"
-name "app-server"
+name "app_server"
 run_list(["recipe[apache]"])

--- a/tests/data/roles/monitoring.json
+++ b/tests/data/roles/monitoring.json
@@ -1,0 +1,10 @@
+{
+  "name": "monitoring",
+  "default_attributes": { },
+  "override_attributes": { },
+  "json_class": "Chef::Role",
+  "description": "This is just a monitoring role, no big deal.",
+  "run_list": [
+  ],
+  "chef_type": "role"
+}

--- a/tests/data/roles/test_server.rb
+++ b/tests/data/roles/test_server.rb
@@ -1,0 +1,2 @@
+description "Test server"
+name "test_server"

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -197,16 +197,17 @@ module SearchNodeTests
     assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "alpha.example.com" }.class
     assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "beta.example.com" }.class
     assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "wjc.example.com" }.class
-    assert_equal 3, nodes.length
+    assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "withoutrole.example.com" }.class
+    assert_equal 4, nodes.length
   end
 
   def test_search_node_with_wide_filter
-    nodes = search(:node, "role:test_server AND chef_environment:default")
+    nodes = search(:node, "role:test_server AND chef_environment:_default")
     assert_equal 3, nodes.length
   end
 
   def test_search_node_with_narrow_filter
-    nodes = search(:node, "role:beta_server")
+    nodes = search(:node, "role:app_server")
     assert_equal 1, nodes.length
   end
 
@@ -216,8 +217,27 @@ module SearchNodeTests
   end
 
   def test_search_node_without_json_class
-    nodes = search(:node, "chef_environment:default")
-    assert_equal 3, nodes.length
+    nodes = search(:node, "chef_environment:_default")
+    assert_equal 4, nodes.length
+  end
+
+  def test_role_accessible
+    nodes = search(:node, "hostname:beta.example.com")
+    assert_equal 1, nodes.length
+
+    node = nodes.first
+    assert_equal node.class, Chef::Node
+    assert_equal false, node['roles'].nil?
+    assert_equal node['roles'], ["test_server", "app_server"]
+  end
+
+  def test_role_always_present
+    nodes = search(:node, "hostname:withoutrole.example.com")
+    assert_equal 1, nodes.length
+
+    node = nodes.first
+    assert_equal node.class, Chef::Node
+    assert_equal node['roles'], []
   end
 end
 
@@ -229,7 +249,7 @@ module SearchRoleTests
   end
 
   def test_rb_search
-    roles = search(:role, "name:app-server")
+    roles = search(:role, "name:app_server")
     assert_equal 1, roles.length
     assert_equal roles.first.description, "App server"
   end

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -202,7 +202,7 @@ module SearchNodeTests
 
   def test_search_node_with_wide_filter
     nodes = search(:node, "role:test_server AND chef_environment:default")
-    assert_equal 2, nodes.length
+    assert_equal 3, nodes.length
   end
 
   def test_search_node_with_narrow_filter

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -25,6 +25,7 @@ require "chef"
 # the location of the data_bag
 Chef::Config[:solo] = true
 Chef::Config[:data_bag_path] = "#{File.dirname(__FILE__)}/data/data_bags"
+Chef::Config[:role_path] = "#{File.dirname(__FILE__)}/data/roles"
 
 # load the extension
 require File.expand_path('../../libraries/search', __FILE__)
@@ -220,9 +221,24 @@ module SearchNodeTests
   end
 end
 
+module SearchRoleTests
+  def test_json_search
+    roles = search(:role, "name:monitoring")
+    assert_equal 1, roles.length
+    assert_equal roles.first.name, "monitoring"
+  end
+
+  def test_rb_search
+    roles = search(:role, "name:app-server")
+    assert_equal 1, roles.length
+    assert_equal roles.first.description, "App server"
+  end
+end
+
 class TestImplicitSearchDB < Test::Unit::TestCase
   include SearchDbTests
   include SearchNodeTests
+  include SearchRoleTests
 
   def search(*args, &block)
     # wrapper around creating a new Recipe instance and calling search on it
@@ -236,6 +252,7 @@ end
 class TestExplicitSearchDB < Test::Unit::TestCase
   include SearchDbTests
   include SearchNodeTests
+  include SearchRoleTests
 
   def search(*args, &block)
     Chef::Search::Query.new.search(*args, &block)

--- a/tests/test_search.rb
+++ b/tests/test_search.rb
@@ -196,7 +196,7 @@ module SearchNodeTests
     nodes = search(:node)
     assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "alpha.example.com" }.class
     assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "beta.example.com" }.class
-    assert_equal Hash, nodes.find{ |n| n["hostname"] == "wjc.example.com" }.class
+    assert_equal Chef::Node, nodes.find{ |n| n["hostname"] == "wjc.example.com" }.class
     assert_equal 3, nodes.length
   end
 


### PR DESCRIPTION
- Adds tests for searching for roles
- Makes it possible to define roles using the Ruby DSL
- 4050fe0 Found a bug; all fixtures have the same role (test_server), but only two are found
- f4bd299 Found a silly spec; we always want to get the same type
