### PR TITLE
Allow node data bag path to be configured

### DIFF
--- a/libraries/search/overrides.rb
+++ b/libraries/search/overrides.rb
@@ -63,7 +63,8 @@ module Search
 
     def search_nodes(_query, start, rows, &block)
       _result = []
-      Dir.glob(File.join(Chef::Config[:data_bag_path], "node", "*.json")).map do |f|
+      node_path = Chef::Config[:nodes_path] || File.join(Chef::Config[:data_bag_path], "node")
+      Dir.glob(File.join(node_path, "*.json")).map do |f|
         # parse and hashify the node
         node = Chef::JSONCompat.from_json(IO.read(f))
         if _query.match(node.to_hash)


### PR DESCRIPTION
Make it possible to configure the `node_path` that is used when nodes are searched. This is consistent with `data_bag_path` and `role_path`.
The default is still <data_bag_path>/node/.

This would help for example [knife-solo](http://matschaffer.github.com/knife-solo) as its node objects are by default in "nodes" directory that is sibling to "data_bags". See issue matschaffer/knife-solo#117.
