### PR TITLE
Fix travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Gemfile.lock
+/tests/gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-script: ruby -Ilibraries tests/test_search.rb -v
 rvm:
   - 1.9.3
   - 1.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-language: ruby
-rvm:
-  - "1.9.3"
-  - "1.9.2"
-  - "1.8.7"
-before_install: gem install chef
 script: ruby -Ilibraries tests/test_search.rb -v
+rvm:
+  - 1.9.3
+  - 1.9.2
+  - 1.8.7
+gemfile:
+  - tests/gemfiles/Gemfile.11
+  - tests/gemfiles/Gemfile.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+before_install: gem update --system 1.8.25
 rvm:
   - 1.9.3
   - 1.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 before_install: gem update --system 1.8.25
+before_script:  chef-solo -v
 rvm:
   - 1.9.3
   - 1.9.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'chef', '>= 10.4'
+gem 'rake'
+gem 'ruby-wmi'
+gem 'win32-service', :platforms => [:mswin, :mingw]
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'chef', '>= 10.4'
+gem 'treetop'
 gem 'rake'
 gem 'ruby-wmi'
 gem 'win32-service', :platforms => [:mswin, :mingw]

--- a/README.md
+++ b/README.md
@@ -140,4 +140,4 @@ You can use the standard databag objects in json form
 
 Running tests is as simple as:
 
-    % ruby -Ilibraries tests/test_search.rb -v
+    % rake test

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+#!/usr/bin/env rake
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.pattern = "tests/test_*.rb"
+  t.libs    = %w(libraries)
+end
+
+desc "Run tests"
+task :default => :test

--- a/tests/Gemfile
+++ b/tests/Gemfile
@@ -1,8 +1,0 @@
-source :rubygems
-
-gem 'chef'
-gem 'ruby-wmi'
-gem 'test-unit'
-if(RUBY_PLATFORM.include?('windows'))
-  gem 'win32-service'
-end

--- a/tests/gemfiles/Gemfile.10
+++ b/tests/gemfiles/Gemfile.10
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "chef", "~> 10.0"

--- a/tests/gemfiles/Gemfile.10
+++ b/tests/gemfiles/Gemfile.10
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "chef", "~> 10.0"
+gem "rake"

--- a/tests/gemfiles/Gemfile.11
+++ b/tests/gemfiles/Gemfile.11
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "chef", "~> 11.0"
 gem "rake"
+gem "treetop"

--- a/tests/gemfiles/Gemfile.11
+++ b/tests/gemfiles/Gemfile.11
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "chef", "~> 11.0"
+gem "rake"

--- a/tests/gemfiles/Gemfile.11
+++ b/tests/gemfiles/Gemfile.11
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "chef", "~> 11.0"

--- a/tests/test_data_bags.rb
+++ b/tests/test_data_bags.rb
@@ -28,8 +28,9 @@ Chef::Config[:data_bag_path] = "tests/data/data_bags"
 def data_bag_item(bag, item)
   # wrapper around creating a new Recipe instance and calling data_bag on it
   node = Chef::Node.new()
+  events = Chef::EventDispatch::Dispatcher.new
   cookbooks = Chef::CookbookCollection.new()
-  run_context = Chef::RunContext.new(node, cookbooks)
+  run_context = Chef::RunContext.new(node, cookbooks, events)
   return Chef::Recipe.new("test_cookbook", "test_recipe", run_context).data_bag_item(bag, item)
 end
 
@@ -40,5 +41,5 @@ class TestDataBags < Test::Unit::TestCase
     assert_equal item["age"], 42
     assert_equal item[:age], nil    #upstream code for chef-solo does not use mashes
   end
-  
+
 end


### PR DESCRIPTION
I've updated travis configuration to make the tests pass:
- separate gemfiles and matrix build for chef versions 10 and 11
- latest rubygems 1.x, becase chef doesn't work with rubygems 2.x yet

I've also fixed `tests/test_data_bags.rb` but I don't see any value from running this test file.
