### PR TITLE
Add version to treetop installation so that things work in an omnibus setting

### DIFF
--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -33,7 +33,7 @@ if Chef::Config[:solo]
   rescue LoadError
     run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
     chef_gem = Chef::Resource::ChefGem.new("treetop", run_context)
-    chef_gem.version('1.4.10')
+    chef_gem.version('>= 1.4')
     chef_gem.run_action(:install)
   end
 

--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -32,7 +32,9 @@ if Chef::Config[:solo]
     require 'treetop'
   rescue LoadError
     run_context = Chef::RunContext.new(Chef::Node.new, {}, Chef::EventDispatch::Dispatcher.new)
-    Chef::Resource::ChefGem.new("treetop", run_context).run_action(:install)
+    chef_gem = Chef::Resource::ChefGem.new("treetop", run_context)
+    chef_gem.version('1.4.10')
+    chef_gem.run_action(:install)
   end
 
   require 'search/overrides'


### PR DESCRIPTION
I couldn't get installation working in omnibus because I kept getting an "Illformed requirement" error. Apparently, if the version isn't set, it fails when creating a gem dependency. I'm not sure if the error comes up in other environments, but I'm in an omnibus one. Things seem to work fine with this, though.

There might be a more elegant fix, but I stopped here.
