### PR TITLE
Add cookbook vagrant-save

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 chef-solo-search Changelog
 ==========================
 
+Version 0.4.1, July 15, 2013
+----------------------------
+* Added cookbook 'vagrant-save' to save node data.
+
 Version 0.4.0, March 8, 2013
 ----------------------------
 * Added support for 'chef_environment:_default' to queries.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ You can use the standard node objects in json form.
       ]
     }
 
+#### Vagrant
+If you are using Vagrant, you can generate json node data from your
+Vagrant nodes, and then search on this node data as documented above. To
+generate json node data, add the following to the end of your Vagrant
+node's run-list:
+
+    recipe[chef-solo-search::vagrant-save]
+
+The `vagrant-save` recipe assumes that your vagrant VM has its shared
+data directory mounted on `/vagrant`. Node data is written to
+`/vagrant/data_bags/node/<hostname>.json`.
+
 ### Databags
 You can use the standard databag objects in json form
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "markus.korn@edelight.de"
 license          "Apache 2.0"
 description      "Data bag search for Chef Solo"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.4.0"
+version          "0.4.1"
 
 %w{ ubuntu debian redhat centos fedora freebsd}.each do |os|
   supports os

--- a/recipes/vagrant-save.rb
+++ b/recipes/vagrant-save.rb
@@ -1,0 +1,11 @@
+# This recipe saves node data to the vagrant path
+# This allows saved nodes to automatically appear in searches
+
+directory "/vagrant/data_bags/node" do
+	mode 00755
+end
+
+template "/vagrant/data_bags/node/#{node.hostname}.json" do
+	mode 00644
+	source 'vagrant.json.erb'
+end

--- a/templates/default/vagrant.json.erb
+++ b/templates/default/vagrant.json.erb
@@ -1,0 +1,1 @@
+<%= require 'json'; JSON.pretty_generate(@node) %>


### PR DESCRIPTION
Please add recipe `vagrant-save`, which automatically generates a JSON representation of each node that runs this recipe. The generated file can then be used in subsequent chef-solo-search searches.
